### PR TITLE
Updated PotPlayer information

### DIFF
--- a/data/media.xml
+++ b/data/media.xml
@@ -198,8 +198,10 @@
 		<file>PotPlayer64.exe</file>
 		<file>PotPlayerMini.exe</file>
 		<file>PotPlayerMini64.exe</file>
+		<file>sumire.exe</file>
 		<folder>%ProgramFiles%\Daum\PotPlayer\</folder>
 		<folder>%ProgramW6432%\Daum\PotPlayer\</folder>
+		<folder>%ProgramFiles%\LAV Filters\x86\PotPlayer\</folder>
 	</player>
 	<!-- SMPlayer -->
 	<player>


### PR DESCRIPTION
I noticed after updating my PotPlayer that media player recognition wasn't activating. I don't know if the naming scheme of the new player was instigated by the group that made the codec pack (LAV Filters Megamix from imouto.my) but either way if others are using it they will experience the same issue.

I don't know if the folder line is required, I haven't checked which functions use it but that's the default directory for the codec pack.
