### PR TITLE
Show range of episodes on disk

### DIFF
--- a/src/library/anime_item.cpp
+++ b/src/library/anime_item.cpp
@@ -649,6 +649,18 @@ bool Item::IsEpisodeAvailable(int number) const {
   return local_info_.available_episodes.at(number - 1);
 }
 
+int Item::LatestEpisodeAvailable() const {
+  int latest_ep = GetMyLastWatchedEpisode();
+  auto& iter = local_info_.available_episodes.begin() + latest_ep;
+  while (iter < local_info_.available_episodes.end()) {
+    if (!*iter)
+      return latest_ep;
+    iter++;
+    latest_ep++;
+  }
+  return local_info_.available_episodes.size();
+}
+
 bool Item::IsNextEpisodeAvailable() const {
   return IsEpisodeAvailable(GetMyLastWatchedEpisode() + 1);
 }

--- a/src/library/anime_item.h
+++ b/src/library/anime_item.h
@@ -137,6 +137,7 @@ public:
   void SetUserSynonyms(const std::vector<std::wstring>& synonyms);
 
   bool IsEpisodeAvailable(int number) const;
+  int LatestEpisodeAvailable() const;
   bool IsNextEpisodeAvailable() const;
   bool UserSynonymsAvailable() const;
 

--- a/src/ui/dlg/dlg_anime_list.cpp
+++ b/src/ui/dlg/dlg_anime_list.cpp
@@ -513,9 +513,15 @@ void AnimeListDialog::ListView::RefreshItem(int index) {
           if (IsAllEpisodesAvailable(*anime_item)) {
             AppendString(text, L"All episodes are in library folders");
           } else {
-            if (anime_item->IsNextEpisodeAvailable())
-              AppendString(text, L"#" + ToWstr(anime_item->GetMyLastWatchedEpisode() + 1) +
-                                 L" is in library folders");
+            if (anime_item->IsNextEpisodeAvailable()) {
+              int first_available = anime_item->GetMyLastWatchedEpisode() + 1;
+              int last_available = anime_item->LatestEpisodeAvailable();
+              bool more_than_one = (last_available > first_available);
+              AppendString(text, L"#" + ToWstr(first_available)
+                  + (more_than_one ? L"-" + ToWstr(last_available) + L" are "
+                                   : L" is ")
+                  + L"in library folders");
+            }
             if (anime_item->GetLastAiredEpisodeNumber() > anime_item->GetMyLastWatchedEpisode())
               AppendString(text, L"#" + ToWstr(anime_item->GetLastAiredEpisodeNumber()) +
                                  L" is available for download");


### PR DESCRIPTION
Changes the tooltip to read, e.g. "#3-5 are in library folders" when multiple episodes are on disk instead of just "#3 is in library folders"