### PR TITLE
New torrent filter: Preferred Fansub Groups

### DIFF
--- a/src/track/feed_filter.cpp
+++ b/src/track/feed_filter.cpp
@@ -80,24 +80,24 @@ bool EvaluateCondition(const FeedFilterCondition& condition,
         element = ToWstr(anime->GetType());
       is_numeric = true;
       break;
-	case kFeedFilterElement_Meta_Groups:
-		element = L"None";
-		if (anime) {
-			int intid = anime->GetId();
+    case kFeedFilterElement_Meta_Groups:
+      element = L"None";
+      if (anime) {
+        int intid = anime->GetId();
 
-			std::vector<std::wstring> groups;
-			if (anime::GetFansubFilter(intid, groups)) {
-				std::wstring assignedgroups = L"";
-				foreach_(it, groups) {
-					if (!assignedgroups.empty())
-						assignedgroups += L" or ";
-					assignedgroups += L"\"" + *it + L"\"";
-				}
-				element = assignedgroups;
-			}
-		}
+        std::vector<std::wstring> groups;
+        if (anime::GetFansubFilter(intid, groups)) {
+          std::wstring assignedgroups = L"";
+          foreach_(it, groups) {
+            if (!assignedgroups.empty())
+              assignedgroups += L" or ";
+            assignedgroups += L"\"" + *it + L"\"";
+          }
+          element = assignedgroups;
+        }
+      }
 
-		break;
+      break;
     case kFeedFilterElement_User_Status:
       element = ToWstr(anime ? anime->GetMyStatus() : anime::kNotInList);
       is_numeric = true;
@@ -800,7 +800,7 @@ std::wstring FeedFilterManager::TranslateElement(int element) {
       return L"Anime airing status";
     case kFeedFilterElement_Meta_Type:
       return L"Anime type";
-	case kFeedFilterElement_Meta_Groups:
+    case kFeedFilterElement_Meta_Groups:
       return L"Anime preferred groups";
     case kFeedFilterElement_User_Status:
       return L"Anime watching status";

--- a/src/track/feed_filter.cpp
+++ b/src/track/feed_filter.cpp
@@ -80,6 +80,24 @@ bool EvaluateCondition(const FeedFilterCondition& condition,
         element = ToWstr(anime->GetType());
       is_numeric = true;
       break;
+	case kFeedFilterElement_Meta_Groups:
+		element = L"None";
+		if (anime) {
+			int intid = anime->GetId();
+
+			std::vector<std::wstring> groups;
+			if (anime::GetFansubFilter(intid, groups)) {
+				std::wstring assignedgroups = L"";
+				foreach_(it, groups) {
+					if (!assignedgroups.empty())
+						assignedgroups += L" or ";
+					assignedgroups += L"\"" + *it + L"\"";
+				}
+				element = assignedgroups;
+			}
+		}
+
+		break;
     case kFeedFilterElement_User_Status:
       element = ToWstr(anime ? anime->GetMyStatus() : anime::kNotInList);
       is_numeric = true;
@@ -610,6 +628,7 @@ void FeedFilterManager::InitializeShortcodes() {
   element_shortcodes_[kFeedFilterElement_Meta_Episodes] = L"meta_episodes";
   element_shortcodes_[kFeedFilterElement_Meta_DateStart] = L"meta_date_start";
   element_shortcodes_[kFeedFilterElement_Meta_DateEnd] = L"meta_date_end";
+  element_shortcodes_[kFeedFilterElement_Meta_Groups] = L"meta_groups";
   element_shortcodes_[kFeedFilterElement_User_Status] = L"user_status";
   element_shortcodes_[kFeedFilterElement_Local_EpisodeAvailable] = L"local_episode_available";
   element_shortcodes_[kFeedFilterElement_Episode_Title] = L"episode_title";
@@ -781,6 +800,8 @@ std::wstring FeedFilterManager::TranslateElement(int element) {
       return L"Anime airing status";
     case kFeedFilterElement_Meta_Type:
       return L"Anime type";
+	case kFeedFilterElement_Meta_Groups:
+      return L"Anime preferred groups";
     case kFeedFilterElement_User_Status:
       return L"Anime watching status";
     case kFeedFilterElement_Episode_Number:

--- a/src/track/feed_filter.h
+++ b/src/track/feed_filter.h
@@ -35,6 +35,7 @@ enum FeedFilterElement {
   kFeedFilterElement_Meta_Episodes,
   kFeedFilterElement_Meta_DateStart,
   kFeedFilterElement_Meta_DateEnd,
+  kFeedFilterElement_Meta_Groups,
   kFeedFilterElement_User_Status,
   kFeedFilterElement_Local_EpisodeAvailable,
   kFeedFilterElement_Episode_Title,

--- a/src/ui/dlg/dlg_feed_condition.cpp
+++ b/src/ui/dlg/dlg_feed_condition.cpp
@@ -193,8 +193,8 @@ void FeedConditionDialog::ChooseElement(int element_index) {
       ADD_OPERATOR(kFeedFilterOperator_NotEquals);
       break;
     case kFeedFilterElement_Episode_Title:
-	case kFeedFilterElement_Episode_Group:
-	case kFeedFilterElement_Meta_Groups:
+    case kFeedFilterElement_Episode_Group:
+    case kFeedFilterElement_Meta_Groups:
     case kFeedFilterElement_Episode_VideoType:
     case kFeedFilterElement_File_Title:
     case kFeedFilterElement_File_Category:
@@ -306,11 +306,11 @@ void FeedConditionDialog::ChooseElement(int element_index) {
       value_combo_.AddString(L"%watched%");
       value_combo_.AddString(L"%total%");
       break;
-	case kFeedFilterElement_Meta_Groups:
+    case kFeedFilterElement_Meta_Groups:
       RECREATE_COMBO(CBS_DROPDOWN);
-	  value_combo_.AddString(L"%group%");
-	  value_combo_.AddString(L"None");
-	  break;
+      value_combo_.AddString(L"%group%");
+      value_combo_.AddString(L"None");
+      break;
     case kFeedFilterElement_Episode_Version:
       RECREATE_COMBO(CBS_DROPDOWN);
       value_combo_.AddString(L"2");

--- a/src/ui/dlg/dlg_feed_condition.cpp
+++ b/src/ui/dlg/dlg_feed_condition.cpp
@@ -193,7 +193,8 @@ void FeedConditionDialog::ChooseElement(int element_index) {
       ADD_OPERATOR(kFeedFilterOperator_NotEquals);
       break;
     case kFeedFilterElement_Episode_Title:
-    case kFeedFilterElement_Episode_Group:
+	case kFeedFilterElement_Episode_Group:
+	case kFeedFilterElement_Meta_Groups:
     case kFeedFilterElement_Episode_VideoType:
     case kFeedFilterElement_File_Title:
     case kFeedFilterElement_File_Category:
@@ -305,6 +306,11 @@ void FeedConditionDialog::ChooseElement(int element_index) {
       value_combo_.AddString(L"%watched%");
       value_combo_.AddString(L"%total%");
       break;
+	case kFeedFilterElement_Meta_Groups:
+      RECREATE_COMBO(CBS_DROPDOWN);
+	  value_combo_.AddString(L"%group%");
+	  value_combo_.AddString(L"None");
+	  break;
     case kFeedFilterElement_Episode_Version:
       RECREATE_COMBO(CBS_DROPDOWN);
       value_combo_.AddString(L"2");


### PR DESCRIPTION
This filter will compare the list of assigned preferred filters against a string value. Useful if matching against "None" and "%group%", the former if there are no groups set as preferred, the later is the current group that is being processed against the incoming torrent group.

EXAMPLE FILTER: Discard torrents that do not specifically match the assigned fansub group:
Anime preferred groups - is not - None
Anime preferred groups - does not contain - %group%
Action: Discard

EXAMPLE FILTER: Discard horriblesubs unless it is specifically set as the preferred fansub group:
Episode fansub group - is - Horriblesubs
Anime preferred groups - does not contain - Horriblesubs
Action: Discard


Note: The group list is built every time the condition is checked, which is probably not terribly performant. Feel free to refactor this with a way of caching this information ahead of time, if you like.

If you prefer different filter and short names, feel free to refactor at your discretion.