### PR TITLE
Indicating missing episodes in the anime list

### DIFF
--- a/src/ui/dlg/dlg_anime_list.cpp
+++ b/src/ui/dlg/dlg_anime_list.cpp
@@ -555,59 +555,59 @@ void AnimeListDialog::ListView::RefreshItem(int index) {
       if (button_visible[1])
         rect_item.right -= button_rect[1].Width();
 
-	  if (columns[kColumnUserProgress].visible && rect_item.PtIn(pt) && anime_item->IsInList()) {
-		  std::wstring text;
-		  std::vector<int> missing;
+      if (columns[kColumnUserProgress].visible && rect_item.PtIn(pt) && anime_item->IsInList()) {
+        std::wstring text;
+        std::vector<int> missing;
 
-		  for (int i = 0; i < anime_item->GetLastAiredEpisodeNumber(true); i++)
-			  if (!anime_item->IsEpisodeAvailable(i + 1))
-				  missing.push_back(i + 1);
+        for (int i = 0; i < anime_item->GetLastAiredEpisodeNumber(true); i++)
+          if (!anime_item->IsEpisodeAvailable(i + 1))
+            missing.push_back(i + 1);
 
-		  // No episodes are missing
-		  if (missing.empty())
-			  // That's alright
-			  AppendString(text, L"All episodes are in library folders");
-		  // If more than episodes we can display are missing
-		  else if (missing.size() > 10)
-			  // Print at least something for the user
-			  AppendString(text, L"More than 10 episodes are missing");
-		  // We are missing at least one episode
-		  else {
-			  // String stream to format missing episodes output
-			  std::wostringstream stream;
+        // No episodes are missing
+        if (missing.empty())
+          // That's alright
+          AppendString(text, L"All episodes are in library folders");
+        // If more than episodes we can display are missing
+        else if (missing.size() > 10)
+          // Print at least something for the user
+          AppendString(text, L"More than 10 episodes are missing");
+        // We are missing at least one episode
+        else {
+          // String stream to format missing episodes output
+          std::wostringstream stream;
 
-			  for (auto& i = missing.begin(); i != missing.end(); i++) {
-				  // First item: add "##"
-				  if (i == missing.begin())
-					  stream << L"#" << (*i);
-				  // Last item: add " and ##"
-				  else if (i + 1 == missing.end())
-					  stream << L" and #" << (*i);
-				  // Intermediate items: add ", ##"
-				  else
-					  stream << L", #" << (*i);
-			  }
+          for (auto& i = missing.begin(); i != missing.end(); i++) {
+            // First item: add "##"
+            if (i == missing.begin())
+              stream << L"#" << (*i);
+            // Last item: add " and ##"
+            else if (i + 1 == missing.end())
+              stream << L" and #" << (*i);
+            // Intermediate items: add ", ##"
+            else
+              stream << L", #" << (*i);
+          }
 
-			  // Add is/are missing at the end
-			  stream << (missing.size() == 1 ? L" is missing" : L" are missing");
+          // Add is/are missing at the end
+          stream << (missing.size() == 1 ? L" is missing" : L" are missing");
 
-			  // Append built string
-			  AppendString(text, stream.str());
+          // Append built string
+          AppendString(text, stream.str());
 
-			  // If the next episode is available
-			  if (anime_item->IsNextEpisodeAvailable())
-				  AppendString(text, L"#" + ToWstr(anime_item->GetMyLastWatchedEpisode() + 1) +
-					  L" is in library folders");
-		  }
+          // If the next episode is available
+          if (anime_item->IsNextEpisodeAvailable())
+            AppendString(text, L"#" + ToWstr(anime_item->GetMyLastWatchedEpisode() + 1) +
+              L" is in library folders");
+        }
 
-		  // If there is a new episode aired and downloadable
-		  if (anime_item->GetLastAiredEpisodeNumber() > anime_item->GetMyLastWatchedEpisode())
-			  AppendString(text, L"#" + ToWstr(anime_item->GetLastAiredEpisodeNumber()) +
-				  L" is available for download");
+        // If there is a new episode aired and downloadable
+        if (anime_item->GetLastAiredEpisodeNumber() > anime_item->GetMyLastWatchedEpisode())
+          AppendString(text, L"#" + ToWstr(anime_item->GetLastAiredEpisodeNumber()) +
+            L" is available for download");
 
-		  if (!text.empty())
-			  update_tooltip(kTooltipEpisodeAvailable, text.c_str(), &rect_item);
-	  }
+        if (!text.empty())
+          update_tooltip(kTooltipEpisodeAvailable, text.c_str(), &rect_item);
+      }
       if (button_visible[0] && button_rect[0].PtIn(pt))
         update_tooltip(kTooltipEpisodeMinus, L"-1 episode", &button_rect[0]);
       if (button_visible[1] && button_rect[1].PtIn(pt))

--- a/src/ui/dlg/dlg_anime_list.cpp
+++ b/src/ui/dlg/dlg_anime_list.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <set>
+#include <sstream>
 
 #include "base/foreach.h"
 #include "base/gfx.h"
@@ -554,23 +555,59 @@ void AnimeListDialog::ListView::RefreshItem(int index) {
       if (button_visible[1])
         rect_item.right -= button_rect[1].Width();
 
-      if (columns[kColumnUserProgress].visible && rect_item.PtIn(pt)) {
-        if (anime_item->IsInList()) {
-          std::wstring text;
-          if (IsAllEpisodesAvailable(*anime_item)) {
-            AppendString(text, L"All episodes are in library folders");
-          } else {
-            if (anime_item->IsNextEpisodeAvailable())
-              AppendString(text, L"#" + ToWstr(anime_item->GetMyLastWatchedEpisode() + 1) +
-                                 L" is in library folders");
-            if (anime_item->GetLastAiredEpisodeNumber() > anime_item->GetMyLastWatchedEpisode())
-              AppendString(text, L"#" + ToWstr(anime_item->GetLastAiredEpisodeNumber()) +
-                                 L" is available for download");
-          }
-          if (!text.empty())
-            update_tooltip(kTooltipEpisodeAvailable, text.c_str(), &rect_item);
-        }
-      }
+	  if (columns[kColumnUserProgress].visible && rect_item.PtIn(pt) && anime_item->IsInList()) {
+		  std::wstring text;
+		  std::vector<int> missing;
+
+		  for (int i = 0; i < anime_item->GetLastAiredEpisodeNumber(true); i++)
+			  if (!anime_item->IsEpisodeAvailable(i + 1))
+				  missing.push_back(i + 1);
+
+		  // No episodes are missing
+		  if (missing.empty())
+			  // That's alright
+			  AppendString(text, L"All episodes are in library folders");
+		  // If more than episodes we can display are missing
+		  else if (missing.size() > 10)
+			  // Print at least something for the user
+			  AppendString(text, L"More than 10 episodes are missing");
+		  // We are missing at least one episode
+		  else {
+			  // String stream to format missing episodes output
+			  std::wostringstream stream;
+
+			  for (auto& i = missing.begin(); i != missing.end(); i++) {
+				  // First item: add "##"
+				  if (i == missing.begin())
+					  stream << L"#" << (*i);
+				  // Last item: add " and ##"
+				  else if (i + 1 == missing.end())
+					  stream << L" and #" << (*i);
+				  // Intermediate items: add ", ##"
+				  else
+					  stream << L", #" << (*i);
+			  }
+
+			  // Add is/are missing at the end
+			  stream << (missing.size() == 1 ? L" is missing" : L" are missing");
+
+			  // Append built string
+			  AppendString(text, stream.str());
+
+			  // If the next episode is available
+			  if (anime_item->IsNextEpisodeAvailable())
+				  AppendString(text, L"#" + ToWstr(anime_item->GetMyLastWatchedEpisode() + 1) +
+					  L" is in library folders");
+		  }
+
+		  // If there is a new episode aired and downloadable
+		  if (anime_item->GetLastAiredEpisodeNumber() > anime_item->GetMyLastWatchedEpisode())
+			  AppendString(text, L"#" + ToWstr(anime_item->GetLastAiredEpisodeNumber()) +
+				  L" is available for download");
+
+		  if (!text.empty())
+			  update_tooltip(kTooltipEpisodeAvailable, text.c_str(), &rect_item);
+	  }
       if (button_visible[0] && button_rect[0].PtIn(pt))
         update_tooltip(kTooltipEpisodeMinus, L"-1 episode", &button_rect[0]);
       if (button_visible[1] && button_rect[1].PtIn(pt))


### PR DESCRIPTION
Commit message: "Modified a bit the tooltip displayed when hovering on an anime list entry:

Now displaying a message telling which episodes are missing, since the
progress bar doesn't really tell exactly which episodes are missing."

I don't really know why git thinks the whole file changed but well, maybe a mistake on my end.

Anyway, code style should be the same as everything else, and this commit doesn't change a lot of things, just modifies the tooltip a bit.

Now when hovering on an anime list entry, it can tell:

- "All episodes are in library folders" (Same as before)
- Or "#x is missing" (New)
- Or "#x, ..., #y and #z are missing" (New)
- Or "More than 10 episodes are missing" (New)
- And "#x is available for download" (Same as before)

Missing episodes are based on the latest aired episode.

For example if I have an anime where 10 out of 13 episodes aired, and I have the episodes 1, 2, 3, 7, 9, the line displayed will be:

    "#4, #5, #6, #8 and #10 are missing. #10 is available for download"

This doesn't change a lot of things, but I hate having to go to the anime folder checking which episodes are missing, so ...

The "More than 10 episodes are missing" is to avoid having a really long line, and when you have that much episodes missing, you just need to download a batch anyway.

PS: Latest aired and downloadable episode is printed two times and I don't know if it should or not, but if it should not this can be fixed just by not checking this one, so ...

PS2: Oh and btw, I know the application allows to just search for an anime torrent and automatically selects the missing ones, but sometimes it doesn't, or I don't remember the other reasons but quite a few times I needed this little thing, so ... well here it is.