### PR TITLE
Add auto-download support for Deluge

### DIFF
--- a/project/vs2013/Taiga.vcxproj
+++ b/project/vs2013/Taiga.vcxproj
@@ -200,6 +200,7 @@
     <ClCompile Include="..\..\src\track\recognition_score.cpp" />
     <ClCompile Include="..\..\src\track\recognition_validate.cpp" />
     <ClCompile Include="..\..\src\track\search.cpp" />
+    <ClCompile Include="..\..\src\track\torrent_client.cpp" />
     <ClCompile Include="..\..\src\ui\dialog.cpp" />
     <ClCompile Include="..\..\src\ui\dlg\dlg_about.cpp" />
     <ClCompile Include="..\..\src\ui\dlg\dlg_anime_info.cpp" />
@@ -355,6 +356,7 @@
     <ClInclude Include="..\..\src\track\monitor.h" />
     <ClInclude Include="..\..\src\track\recognition.h" />
     <ClInclude Include="..\..\src\track\search.h" />
+    <ClInclude Include="..\..\src\track\torrent_client.h" />
     <ClInclude Include="..\..\src\ui\dialog.h" />
     <ClInclude Include="..\..\src\ui\dlg\dlg_about.h" />
     <ClInclude Include="..\..\src\ui\dlg\dlg_anime_info.h" />

--- a/project/vs2013/Taiga.vcxproj.filters
+++ b/project/vs2013/Taiga.vcxproj.filters
@@ -355,6 +355,9 @@
     <ClCompile Include="..\..\src\track\search.cpp">
       <Filter>track</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\track\torrent_client.cpp">
+      <Filter>track</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ui\dialog.cpp">
       <Filter>ui</Filter>
     </ClCompile>
@@ -816,6 +819,9 @@
     <ClInclude Include="..\..\src\track\search.h">
       <Filter>track</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\track\torrent_client.h">
+      <Filter>track</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ui\dialog.h">
       <Filter>ui</Filter>
     </ClInclude>

--- a/project/vs2013/Taiga.vcxproj.filters
+++ b/project/vs2013/Taiga.vcxproj.filters
@@ -819,9 +819,6 @@
     <ClInclude Include="..\..\src\track\search.h">
       <Filter>track</Filter>
     </ClInclude>
-    <ClCompile Include="..\..\src\track\torrent_client.h">
-      <Filter>track</Filter>
-    </ClCompile>
     <ClInclude Include="..\..\src\ui\dialog.h">
       <Filter>ui</Filter>
     </ClInclude>
@@ -938,6 +935,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\win\ctrl\win_ctrl.h">
       <Filter>win\ctrl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\track\torrent_client.h">
+      <Filter>track</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/base/file.cpp
+++ b/src/base/file.cpp
@@ -132,7 +132,7 @@ bool Execute(const std::wstring& path, const std::wstring& parameters) {
     return ExecuteFile(path, parameters);
 
   auto value = ShellExecute(nullptr, L"open", path.c_str(), parameters.c_str(),
-                            nullptr, SW_SHOWNORMAL);
+                            nullptr, SW_HIDE);
   return reinterpret_cast<int>(value) > 32;
 }
 

--- a/src/track/feed.h
+++ b/src/track/feed.h
@@ -25,6 +25,7 @@
 #include "base/types.h"
 #include "library/anime_episode.h"
 #include "track/feed_filter.h"
+#include "torrent_client.h"
 
 namespace pugi {
 class xml_document;
@@ -163,6 +164,8 @@ private:
   std::vector<std::wstring> download_queue_;
   std::vector<Feed> feeds_;
   std::vector<std::wstring> file_archive_;
+
+  TorrentClients clients_;
 };
 
 extern class Aggregator Aggregator;

--- a/src/track/feed_aggregator.cpp
+++ b/src/track/feed_aggregator.cpp
@@ -307,17 +307,16 @@ void Aggregator::HandleFeedDownloadOpen(FeedItem& feed_item,
       }
       if (!download_path.empty() && !FolderExists(download_path)) {
         LOG(LevelWarning, L"Folder doesn't exist.\n"
-          L"Path: " + download_path);
+                          L"Path: " + download_path);
         download_path.clear();
       }
       // Create a subfolder using the anime title as its name
       if (!download_path.empty() &&
-        Settings.GetBool(taiga::kTorrent_Download_CreateSubfolder)) {
+          Settings.GetBool(taiga::kTorrent_Download_CreateSubfolder)) {
         std::wstring anime_title;
         if (anime_item) {
           anime_title = anime_item->GetTitle();
-        }
-        else {
+        } else {
           anime_title = feed_item.episode_data.anime_title();
         }
         ValidateFileName(anime_title);
@@ -326,10 +325,9 @@ void Aggregator::HandleFeedDownloadOpen(FeedItem& feed_item,
         download_path += anime_title;
         if (!CreateFolder(download_path)) {
           LOG(LevelError, L"Subfolder could not be created.\n"
-            L"Path: " + download_path);
+                          L"Path: " + download_path);
           download_path.clear();
-        }
-        else {
+        } else {
           if (anime_item) {
             anime_item->SetFolder(download_path);
             Settings.Save();

--- a/src/track/feed_aggregator.cpp
+++ b/src/track/feed_aggregator.cpp
@@ -345,7 +345,14 @@ void Aggregator::HandleFeedDownloadOpen(FeedItem& feed_item,
   }
   else {
     // Default behavior if no application was found
-    Execute(app_path, L"\"" + file + L"\"");
+    std::wstring parameters;
+
+    if (!download_path.empty())
+      parameters = L"\"" + download_path + L"\" ";
+
+    parameters += L"\"" + file + L"\"";
+
+    Execute(app_path, parameters);
   }
 }
 

--- a/src/track/torrent_client.cpp
+++ b/src/track/torrent_client.cpp
@@ -1,0 +1,68 @@
+/*
+** Taiga
+** Copyright (C) 2010-2014, Eren Okka
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "base/file.h"
+#include "base/log.h"
+#include "base/string.h"
+#include "track/torrent_client.h"
+
+void TorrentClient::DownloadTorrent(const std::wstring& app_path, const std::wstring& download_path, const std::wstring& file) {
+  std::wstring parameters = GenerateParameters(download_path, file);
+  Execute(app_path, parameters);
+}
+
+std::wstring Deluge::GenerateParameters(const std::wstring& download_path, const std::wstring& file) {
+  return L"add -p \\\"" + download_path + L"\\\" \\\"" + file + L"\\\"";
+}
+
+std::wstring& Deluge::kBinaryName() {
+  static std::wstring *x = new std::wstring(L"deluge-console.exe");
+  return *x;
+}
+
+std::wstring UTorrent::GenerateParameters(const std::wstring& download_path, const std::wstring& file) {
+  std::wstring parameters;
+  if (!download_path.empty()) {
+    parameters = L"/directory \"" + download_path + L"\" ";
+  }
+
+  return parameters + L"\"" + file + L"\"";
+}
+
+std::wstring& UTorrent::kBinaryName() {
+  static std::wstring *x = new std::wstring(L"uTorrent.exe");
+  return *x;
+}
+
+TorrentClients::TorrentClients() {
+  clients_[Deluge::kBinaryName()]   = std::make_shared<Deluge>();
+  clients_[UTorrent::kBinaryName()] = std::make_shared<UTorrent>();
+}
+
+std::shared_ptr<TorrentClient> TorrentClients::GetClientByPath(const std::wstring& path) {
+  std::wstring app = GetFileName(path);
+
+  auto item = clients_.find(app);
+  if (item != clients_.end()) {
+    return item->second;
+  }
+
+  LOG(LevelNotice, L"Application is not a supported torrent client:\n"
+                   L"Path: " + app);
+  return nullptr;
+}

--- a/src/track/torrent_client.h
+++ b/src/track/torrent_client.h
@@ -1,0 +1,60 @@
+/*
+** Taiga
+** Copyright (C) 2010-2014, Eren Okka
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TAIGA_TRACK_TORRENT_CLIENT_H
+#define TAIGA_TRACK_TORRENT_CLIENT_H
+
+#include <string>
+#include <map>
+#include <memory>
+
+class TorrentClient;
+
+class TorrentClients {
+public:
+  TorrentClients();
+
+  std::shared_ptr<TorrentClient> GetClientByPath(const std::wstring& path);
+private:
+  std::map<std::wstring, std::shared_ptr<TorrentClient>> clients_;
+};
+
+class TorrentClient {
+public:  
+  virtual ~TorrentClient() {}
+
+  void DownloadTorrent(const std::wstring& app_path, const std::wstring& download_path, const std::wstring& file);
+protected:
+  virtual std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file) = 0;
+};
+
+class Deluge : public TorrentClient {
+public:
+  static std::wstring& kBinaryName();
+private:
+  std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file);
+};
+
+class UTorrent : public TorrentClient {
+public:
+  static std::wstring& kBinaryName();
+private:
+  std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file);
+};
+
+#endif  // TAIGA_TRACK_TORRENT_CLIENT_H

--- a/src/track/torrent_client.h
+++ b/src/track/torrent_client.h
@@ -29,7 +29,8 @@ class TorrentClients {
 public:
   TorrentClients();
 
-  std::shared_ptr<TorrentClient> GetClientByPath(const std::wstring& path);
+  std::shared_ptr<TorrentClient> GetClientByPath(const std::wstring& path) const;
+  void AddClient(const std::wstring& name, const std::shared_ptr<TorrentClient> client);
 private:
   std::map<std::wstring, std::shared_ptr<TorrentClient>> clients_;
 };
@@ -39,22 +40,25 @@ public:
   virtual ~TorrentClient() {}
 
   void DownloadTorrent(const std::wstring& app_path, const std::wstring& download_path, const std::wstring& file);
+  virtual void RegisterClient(TorrentClients& clients) = 0;
 protected:
-  virtual std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file) = 0;
+  virtual std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file) const = 0;
+  virtual std::wstring GetAppPath(const std::wstring& app_path) const;
 };
 
-class Deluge : public TorrentClient {
+class Deluge : public TorrentClient, public std::enable_shared_from_this<Deluge> {
 public:
-  static std::wstring& kBinaryName();
+  void RegisterClient(TorrentClients& clients) override;
 private:
-  std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file);
+  std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file) const override;
+  std::wstring GetAppPath(const std::wstring& app_path) const override;
 };
 
-class UTorrent : public TorrentClient {
+class UTorrent : public TorrentClient, public std::enable_shared_from_this<UTorrent> {
 public:
-  static std::wstring& kBinaryName();
+  void RegisterClient(TorrentClients& clients) override;
 private:
-  std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file);
+  std::wstring GenerateParameters(const std::wstring& download_path, const std::wstring& file) const override;
 };
 
 #endif  // TAIGA_TRACK_TORRENT_CLIENT_H


### PR DESCRIPTION
I have been using this for quite a while in another format (as a stand-alone app that calls `deluge-console.exe` with the arguments coming from Taiga) to make my life easier and enable Deluge to automatically download torrents just the same as uTorrent can. I decided somebody else might find this useful so I decided to add it to Taiga itself (it's also more convinient to use for me this way).

For this I have refactored `Aggregator::HandleFeedDownloadOpen` a bit to work not only for uTorrent but for a given `TorrentClient` instance. I added implementation for Deluge and uTorrent but it would be quite straightforward to add additional torrent clients as well.

I'm not sure my code is up to standards but I was trying to keep myself to the other parts of the project and the best practices I know of.

Also a caveat for this to work is that Deluge must be running in non-classic mode (which it does not do by default). I am not aware of any way to add torrents with an associated path.