### PR TITLE
Fix daisuki stream recognition

### DIFF
--- a/src/track/media_stream.cpp
+++ b/src/track/media_stream.cpp
@@ -399,7 +399,7 @@ bool MatchStreamUrl(StreamingVideoProvider stream_provider,
       return SearchRegex(url, L"crunchyroll\\.[a-z.]+/[^/]+/episode-[0-9]+.*-[0-9]+") ||
              SearchRegex(url, L"crunchyroll\\.[a-z.]+/[^/]+/.*-movie-[0-9]+");
     case kStreamDaisuki:
-      return InStr(url, L"daisuki.net/anime/watch/") > -1;
+      return SearchRegex(url, L"daisuki\\.net/[a-z]+/[a-z]+/anime/watch");
     case kStreamPlex:
       return SearchRegex(url,
           L"(?:(?:localhost|\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}):32400|plex.tv)/web/");


### PR DESCRIPTION
Daisuki streaming never actually worked for me but it never bothered me that much to figure out why. At some point they added /us/en/ to the url and changed the watch at the end.

Example:
`http://www.daisuki.net/us/en/anime/watch.MOBILESUITGUNDAMWING.13364.html`