### PR TITLE
Switch MAL API Calls to HTTPS.

### DIFF
--- a/src/sync/myanimelist.cpp
+++ b/src/sync/myanimelist.cpp
@@ -45,7 +45,7 @@ Service::Service() {
 
 void Service::BuildRequest(Request& request, HttpRequest& http_request) {
   http_request.url.host = host_;
-
+  http_request.url.protocol = base::http::kHttps;
   // This doesn't quite help; MAL returns whatever it pleases
   http_request.header[L"Accept"] = L"text/xml, text/*";
   http_request.header[L"Accept-Charset"] = L"utf-8";


### PR DESCRIPTION
Currently, MAL's API supports HTTP and HTTPS (a new introduction by the way for the MAL API). However, Xinil announced in the MAL API club comments section that the MAL API will be switching to pure HTTPS by mid-september. This change reflects the announcement made.

As for the file ending changed, blame github, I just made the change on here since it was one line really needing added.