### PR TITLE
Add Kitsu group to About

### DIFF
--- a/src/ui/dlg/dlg_about.cpp
+++ b/src/ui/dlg/dlg_about.cpp
@@ -109,6 +109,7 @@ BOOL AboutDialog::OnInitDialog() {
       L"\\b Links:\\b0\\line "
       L"\u2022 {\\field{\\*\\fldinst{HYPERLINK \"http://taiga.moe\"}}{\\fldrslt{Home page}}}\\line "
       L"\u2022 {\\field{\\*\\fldinst{HYPERLINK \"https://github.com/erengy/taiga\"}}{\\fldrslt{GitHub repository}}}\\line "
+      L"\u2022 {\\field{\\*\\fldinst{HYPERLINK \"https://kitsu.io/groups/taiga\"}}{\\fldrslt{Kitsu group}}}\\line "
       L"\u2022 {\\field{\\*\\fldinst{HYPERLINK \"https://myanimelist.net/clubs.php?cid=21400\"}}{\\fldrslt{MyAnimeList club}}}\\line "
       L"\u2022 {\\field{\\*\\fldinst{HYPERLINK \"https://twitter.com/taigaapp\"}}{\\fldrslt{Twitter account}}}\\line "
       L"\u2022 {\\field{\\*\\fldinst{HYPERLINK \"irc://irc.rizon.net/taiga\"}}{\\fldrslt{IRC channel}}}"


### PR DESCRIPTION
Adds the [Taiga](https://kitsu.io/groups/taiga) Kitsu group to the about dialog - currently only has the MAL club.