### PR TITLE
Add support for x64 Potplayer from LAV Filters Megamix

### DIFF
--- a/data/media.xml
+++ b/data/media.xml
@@ -274,9 +274,11 @@
 		<file>PotPlayerMini.exe</file>
 		<file>PotPlayerMini64.exe</file>
 		<file>sumire.exe</file>
+		<file>zuikaku.exe</file>
 		<folder>%ProgramFiles%\Daum\PotPlayer\</folder>
 		<folder>%ProgramW6432%\Daum\PotPlayer\</folder>
 		<folder>%ProgramFiles%\LAV Filters\x86\PotPlayer\</folder>
+		<folder>%ProgramFiles(x86)%\LAV Filters\x64\PotPlayer</folder>
 	</player>
 	<!-- SMPlayer -->
 	<player>


### PR DESCRIPTION
I don't think the folder is needed but I include it there just in case.