### PR TITLE
crypto: fix compilation warnings

### DIFF
--- a/src/base/crypto.cpp
+++ b/src/base/crypto.cpp
@@ -46,10 +46,13 @@ bool StringCoder::Encode(const std::wstring& metadata, const std::wstring& data,
   std::string buffer;
   buffer.append(magic_string_);
   buffer.push_back(version_);
-  buffer.append(ConvertSizeToString(converted_metadata.size()));
+  buffer.append(ConvertSizeToString(
+    static_cast<unsigned short>(converted_metadata.size())));
   buffer.append(converted_metadata);
-  buffer.append(ConvertSizeToString(compressed_data.size()));
-  buffer.append(ConvertSizeToString(converted_data.size()));
+  buffer.append(ConvertSizeToString(
+    static_cast<unsigned short>(compressed_data.size())));
+  buffer.append(ConvertSizeToString(
+    static_cast<unsigned short>(converted_data.size())));
   buffer.append(compressed_data);
 
   output = StrToWstr(Base64Encode(buffer));
@@ -111,8 +114,7 @@ std::string StringCoder::ConvertSizeToString(unsigned short value) {
   return output;
 }
 
-unsigned short StringCoder::ReadSize(const std::string& str,
-                                     unsigned short pos) {
+unsigned short StringCoder::ReadSize(const std::string& str, size_t pos) {
   unsigned short result = 0;
   size_t len = sizeof(result);
 

--- a/src/base/crypto.h
+++ b/src/base/crypto.h
@@ -29,7 +29,7 @@ public:
 
 private:
   std::string ConvertSizeToString(unsigned short value);
-  unsigned short ReadSize(const std::string& str, unsigned short pos);
+  unsigned short ReadSize(const std::string& str, size_t pos);
 
   const std::string magic_string_;
   const size_t min_length_;


### PR DESCRIPTION
There were some warnings about conversion between `size_t` and `unsigned short` and possible loss of data.

I'd rather change `unsigned short` to `size_t` in `ReadSize` and `ConvertSizeToString` completely, but it'll break compatibility with older versions of Taiga.