### PR TITLE
Added Date Started / Date Completed Columns

### DIFF
--- a/res/menu.xml
+++ b/res/menu.xml
@@ -201,6 +201,8 @@
 		<item name="Last updated" action="user_last_updated" checked="1"/>
 		<item name="Progress" action="user_progress" checked="1"/>
 		<item name="Score" action="user_rating" checked="1"/>
+		<item name="Date started" action="user_date_started" checked="1"/>
+		<item name="Date completed" action="user_date_completed" checked="1"/>
 		<item type="separator"/>
 		<item name="Reset to defaults" action="ResetAnimeListHeaders()"/>
 	</menu>

--- a/src/library/anime_util.cpp
+++ b/src/library/anime_util.cpp
@@ -1012,6 +1012,10 @@ std::wstring TranslateMyScore(int value, const std::wstring& default_char) {
   }
 }
 
+std::wstring TranslateMyDate(const Date& value, const std::wstring& default_char) {
+  return IsValidDate(value) ? TranslateDate(value) : default_char;
+}
+
 std::wstring TranslateMyScoreFull(int value) {
   switch (taiga::GetCurrentServiceId()) {
     default:

--- a/src/library/anime_util.h
+++ b/src/library/anime_util.h
@@ -96,6 +96,7 @@ void GetProgressRatios(const Item& item, float& ratio_aired, float& ratio_watche
 std::wstring TranslateMyStatus(int value, bool add_count);
 std::wstring TranslateNumber(int value, const std::wstring& default_char = L"-");
 std::wstring TranslateMyScore(int value, const std::wstring& default_char = L"-");
+std::wstring TranslateMyDate(const Date& value, const std::wstring& default_char = L"-");
 std::wstring TranslateMyScoreFull(int value);
 std::wstring TranslateScore(double value);
 std::wstring TranslateStatus(int value);

--- a/src/ui/dlg/dlg_anime_list.cpp
+++ b/src/ui/dlg/dlg_anime_list.cpp
@@ -419,6 +419,8 @@ int AnimeListDialog::ListView::GetDefaultSortOrder(AnimeListColumn column) {
     case kColumnUserLastUpdated:
     case kColumnUserProgress:
     case kColumnUserRating:
+    case kColumnUserDateStarted:
+    case kColumnUserDateCompleted:
       return -1;
     case kColumnAnimeTitle:
     default:
@@ -428,6 +430,10 @@ int AnimeListDialog::ListView::GetDefaultSortOrder(AnimeListColumn column) {
 
 int AnimeListDialog::ListView::GetSortType(AnimeListColumn column) {
   switch (column) {
+    case kColumnUserDateStarted:
+      return ui::kListSortMyDateStart;
+    case kColumnUserDateCompleted:
+      return ui::kListSortMyDateCompleted;
     case kColumnUserLastUpdated:
       return ui::kListSortLastUpdated;
     case kColumnUserProgress:
@@ -1208,6 +1214,14 @@ LRESULT AnimeListDialog::OnListCustomDraw(LPARAM lParam) {
               anime_item->GetMyLastUpdated() == L"0")
             pCD->clrText = GetSysColor(COLOR_GRAYTEXT);
           break;
+        case kColumnUserDateStarted:
+          if (!anime::IsValidDate(anime_item->GetMyDateStart()))
+            pCD->clrText = GetSysColor(COLOR_GRAYTEXT);
+          break;
+        case kColumnUserDateCompleted:
+          if (!anime::IsValidDate(anime_item->GetMyDateEnd()))
+            pCD->clrText = GetSysColor(COLOR_GRAYTEXT);
+          break;
       }
 
       // Indicate currently playing
@@ -1437,6 +1451,12 @@ void AnimeListDialog::RefreshListItemColumns(int index, const anime::Item& anime
       case kColumnUserRating:
         text = anime::TranslateMyScore(anime_item.GetMyScore());
         break;
+      case kColumnUserDateStarted:
+        text = anime::TranslateMyDate(anime_item.GetMyDateStart());
+        break;
+      case kColumnUserDateCompleted:
+        text = anime::TranslateMyDate(anime_item.GetMyDateEnd());
+        break;
     }
     if (!text.empty())
       listview.SetItem(index, column.index, text.c_str());
@@ -1541,6 +1561,14 @@ void AnimeListDialog::ListView::InitializeColumns() {
       {kColumnAnimeSeason, true, i, i++,
        0, static_cast<unsigned short>(ScaleX(90)), static_cast<unsigned short>(ScaleX(90)),
        LVCFMT_RIGHT, L"Season", L"anime_season"})));
+  columns.insert(std::make_pair(kColumnUserDateStarted, ColumnData(
+      {kColumnUserDateStarted, false, i, i++,
+       0, static_cast<unsigned short>(ScaleX(90)), static_cast<unsigned short>(ScaleX(90)),
+       LVCFMT_CENTER, L"Started", L"user_date_started"})));
+  columns.insert(std::make_pair(kColumnUserDateCompleted, ColumnData(
+      {kColumnUserDateCompleted, false, i, i++,
+       0, static_cast<unsigned short>(ScaleX(90)), static_cast<unsigned short>(ScaleX(90)),
+       LVCFMT_CENTER, L"Completed", L"user_date_completed"})));
   columns.insert(std::make_pair(kColumnUserLastUpdated, ColumnData(
       {kColumnUserLastUpdated, false, i, i++,
        0, static_cast<unsigned short>(ScaleX(100)), static_cast<unsigned short>(ScaleX(85)),
@@ -1747,6 +1775,8 @@ AnimeListColumn AnimeListDialog::ListView::TranslateColumnName(const std::wstrin
     {L"user_last_updated", kColumnUserLastUpdated},
     {L"user_progress", kColumnUserProgress},
     {L"user_rating", kColumnUserRating},
+    {L"user_date_started", kColumnUserDateStarted},
+    {L"user_date_completed", kColumnUserDateCompleted},
   };
 
   auto it = names.find(name);

--- a/src/ui/dlg/dlg_anime_list.h
+++ b/src/ui/dlg/dlg_anime_list.h
@@ -47,6 +47,8 @@ enum AnimeListColumn {
   kColumnUserLastUpdated,
   kColumnUserProgress,
   kColumnUserRating,
+  kColumnUserDateStarted,
+  kColumnUserDateCompleted,
 };
 
 class AnimeListDialog : public win::Dialog {

--- a/src/ui/list.cpp
+++ b/src/ui/list.cpp
@@ -86,6 +86,26 @@ int SortListByAiringStatus(const anime::Item& item1, const anime::Item& item2) {
   return CompareValues<int>(item1.GetAiringStatus(), item2.GetAiringStatus());
 }
 
+int SortListByMyDateStart(const anime::Item& item1, const anime::Item& item2) {
+	Date date1 = item1.GetMyDateStart();
+	Date date2 = item2.GetMyDateStart();
+
+	if (date1 != date2)
+		if (!anime::IsValidDate(date1) || !anime::IsValidDate(date2))
+			return anime::IsValidDate(date2) ? base::kLessThan : base::kGreaterThan;
+  return CompareValues<Date>(date1, date2);
+}
+
+int SortListByMyDateCompleted(const anime::Item& item1, const anime::Item& item2) {
+	Date date1 = item1.GetMyDateEnd();
+	Date date2 = item2.GetMyDateEnd();
+
+	if (date1 != date2)
+		if (!anime::IsValidDate(date1) || !anime::IsValidDate(date2))
+			return anime::IsValidDate(date2) ? base::kLessThan : base::kGreaterThan;
+	return CompareValues<Date>(date1, date2);
+}
+
 int SortListByDateStart(const anime::Item& item1, const anime::Item& item2) {
   Date date1 = item1.GetDateStart();
   Date date2 = item2.GetDateStart();
@@ -194,6 +214,10 @@ int SortList(int type, int order, int id1, int id2) {
 
   if (item1 && item2) {
     switch (type) {
+      case kListSortMyDateStart:
+        return SortListByMyDateStart(*item1, *item2);
+      case kListSortMyDateCompleted:
+        return SortListByMyDateCompleted(*item1, *item2);
       case kListSortDateStart:
         return SortListByDateStart(*item1, *item2);
       case kListSortEpisodeCount:
@@ -252,6 +276,8 @@ static int ListViewCompare(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort,
       break;
     }
 
+    case kListSortMyDateCompleted:
+    case kListSortMyDateStart:
     case kListSortDateStart:
     case kListSortEpisodeCount:
     case kListSortLastUpdated:

--- a/src/ui/list.h
+++ b/src/ui/list.h
@@ -34,6 +34,8 @@ enum ListSortType {
   kListSortDateStart,
   kListSortEpisodeCount,
   kListSortEpisodeRange,
+  kListSortMyDateCompleted,
+  kListSortMyDateStart,
   kListSortLastUpdated,
   kListSortPopularity,
   kListSortProgress,

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -475,6 +475,8 @@ static bool AnimeListNeedsResort() {
     case kColumnUserLastUpdated:
     case kColumnUserProgress:
     case kColumnUserRating:
+    case kColumnUserDateStarted:
+    case kColumnUserDateCompleted:
       return true;
   }
   return false;


### PR DESCRIPTION
I opted to go with

- Absolute date (using the existing `anime::TranslateDate` function)
- "Date started" and "Date completed" in the context menu to make it consistent with the label in Anime Information dialog
- Shortened to "Started" and "Completed" in the column title since column would be too large otherwise

If there's any change I need to make, please inform me. Thanks!