### PR TITLE
Allow starting new rewatches via context menu

### DIFF
--- a/res/menu.xml
+++ b/res/menu.xml
@@ -128,6 +128,7 @@
 		<item name="Play &amp;last episode"   action="PlayLast()"/>
 		<item name="Play &amp;next episode"   action="PlayNext()"/>
 		<item name="Play &amp;random episode" action="PlayRandom()"/>
+		<item name="Start new rewatch"        action="StartNewRewatch()"/>
 	</menu>
 	<!-- Edit -->
 	<menu name="Edit">

--- a/src/library/anime_util.cpp
+++ b/src/library/anime_util.cpp
@@ -350,7 +350,7 @@ bool PlayRandomAnime() {
       return true;
   }
 
-  ui::OnAnimeEpisodeNotFound();
+  ui::OnAnimeEpisodeNotFound(L"Play Random Episode");
   return false;
 }
 
@@ -372,7 +372,26 @@ bool PlayRandomEpisode(int anime_id) {
       return true;
   }
 
-  ui::OnAnimeEpisodeNotFound();
+  ui::OnAnimeEpisodeNotFound(L"Play Random Episode");
+  return false;
+}
+
+bool StartNewRewatch(int anime_id) {
+  auto anime_item = AnimeDatabase.FindItem(anime_id);
+
+  if (!anime_item)
+    return false;
+
+  anime_item->SetMyStatus(kWatching);
+  anime_item->SetMyRewatching(true);
+  anime_item->SetMyRewatchingEp(0);
+  anime_item->SetMyLastWatchedEpisode(0);
+
+  if (PlayEpisode(anime_item->GetId(), 0)) {
+    return true;
+  }
+
+  ui::OnAnimeEpisodeNotFound(L"Start New Rewatch");
   return false;
 }
 

--- a/src/library/anime_util.cpp
+++ b/src/library/anime_util.cpp
@@ -382,10 +382,12 @@ bool StartNewRewatch(int anime_id) {
   if (!anime_item)
     return false;
 
-  anime_item->SetMyStatus(kWatching);
-  anime_item->SetMyRewatching(true);
-  anime_item->SetMyRewatchingEp(0);
-  anime_item->SetMyLastWatchedEpisode(0);
+  HistoryItem history_item;
+  history_item.anime_id = anime_item->GetId();
+  history_item.status = kWatching;
+  history_item.enable_rewatching = TRUE;
+  history_item.episode = 0;
+  History.queue.Add(history_item);
 
   if (PlayEpisode(anime_item->GetId(), 0)) {
     return true;

--- a/src/library/anime_util.h
+++ b/src/library/anime_util.h
@@ -51,6 +51,7 @@ bool PlayNextEpisode(int anime_id);
 bool PlayNextEpisodeOfLastWatchedAnime();
 bool PlayRandomAnime();
 bool PlayRandomEpisode(int anime_id);
+bool StartNewRewatch(int anime_id);
 bool LinkEpisodeToAnime(Episode& episode, int anime_id);
 void StartWatching(Item& item, Episode& episode);
 void EndWatching(Item& item, Episode episode);

--- a/src/taiga/action.cpp
+++ b/src/taiga/action.cpp
@@ -676,6 +676,12 @@ void ExecuteAction(std::wstring action, WPARAM wParam, LPARAM lParam) {
   } else if (action == L"PlayRandomAnime") {
     anime::PlayRandomAnime();
 
+  // StartNewRewatch()
+  //   Sets status to Currently Watching and plays first episode.
+  } else if (action == L"StartNewRewatch") {
+    int anime_id = static_cast<int>(lParam);
+    anime::StartNewRewatch(anime_id);
+
   //////////////////////////////////////////////////////////////////////////////
 
   // Season_Load(file)

--- a/src/ui/menu.cpp
+++ b/src/ui/menu.cpp
@@ -148,7 +148,8 @@ void MenuList::UpdateAnime(const anime::Item* anime_item) {
         // Start new rewatch
         if (anime::IsValidEpisodeCount(anime_item->GetEpisodeCount()) &&
             anime_item->GetMyLastWatchedEpisode() == anime_item->GetEpisodeCount() &&
-            anime_item->GetMyRewatching() == FALSE) {
+            anime_item->GetMyRewatching() == FALSE &&
+            anime_item->GetAiringStatus() == anime::kFinishedAiring) {
           menu->CreateItem(L"StartNewRewatch()", L"Start new rewatch");
         }
         break;

--- a/src/ui/menu.cpp
+++ b/src/ui/menu.cpp
@@ -145,6 +145,10 @@ void MenuList::UpdateAnime(const anime::Item* anime_item) {
         if (anime_item->GetEpisodeCount() != 1) {
           menu->CreateItem(L"PlayRandom()", L"Play random episode\tCtrl+R");
         }
+        // Start new rewatch
+        if (anime_item->GetMyLastWatchedEpisode() == anime_item->GetEpisodeCount()) {
+          menu->CreateItem(L"StartNewRewatch()", L"Start new rewatch");
+        }
         break;
       }
     }

--- a/src/ui/menu.cpp
+++ b/src/ui/menu.cpp
@@ -146,7 +146,9 @@ void MenuList::UpdateAnime(const anime::Item* anime_item) {
           menu->CreateItem(L"PlayRandom()", L"Play random episode\tCtrl+R");
         }
         // Start new rewatch
-        if (anime_item->GetMyLastWatchedEpisode() == anime_item->GetEpisodeCount()) {
+        if (anime::IsValidEpisodeCount(anime_item->GetEpisodeCount()) &&
+            anime_item->GetMyLastWatchedEpisode() == anime_item->GetEpisodeCount() &&
+            anime_item->GetMyRewatching() == FALSE) {
           menu->CreateItem(L"StartNewRewatch()", L"Start new rewatch");
         }
         break;

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -648,9 +648,9 @@ void OnAnimeDelete(int id, const string_t& title) {
   DlgSeason.RefreshList();
 }
 
-void OnAnimeEpisodeNotFound() {
+void OnAnimeEpisodeNotFound(const std::wstring& title) {
   win::TaskDialog dlg;
-  dlg.SetWindowTitle(L"Play Random Episode");
+  dlg.SetWindowTitle(title.c_str());
   dlg.SetMainIcon(TD_ICON_ERROR);
   dlg.SetMainInstruction(L"Could not find any episode to play.");
   dlg.Show(DlgMain.GetWindowHandle());

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -91,7 +91,7 @@ int OnHistoryQueueClear();
 int OnHistoryProcessConfirmationQueue(anime::Episode& episode);
 
 void OnAnimeDelete(int id, const string_t& title);
-void OnAnimeEpisodeNotFound();
+void OnAnimeEpisodeNotFound(const std::wstring& title);
 bool OnAnimeFolderNotFound();
 void OnAnimeWatchingStart(const anime::Item& anime_item, const anime::Episode& episode);
 void OnAnimeWatchingEnd(const anime::Item& anime_item, const anime::Episode& episode);


### PR DESCRIPTION
https://github.com/erengy/taiga/issues/234 for screenshots / gifs

UI:

* I made **Start new rewatch** make an error pop up like **Play random episode**, but I also made it so that it still sets it to **Currently watching** despite the unavailable episode. So if the user later has an episode available, they can go to their **Currently watching** list and play the next episode immediately without having to click **Start new rewatch** again.
* **Start new rewatch** could have a separator to make it separate from the **Play ___** features.

Code:

* Instead of making `OnAnimeEpisodeNotFound` take a title string like I did, it could be better to create another type (so `OnRandomAnimeEpisodeNotFound` vs` OnRewatchAnimeEpisodeNotFound`). Not sure which is better.

Let me know if there are any changes needed to be made.