### PR TITLE
Update deluge-console file add to support paths with two consecutive spaces

### DIFF
--- a/src/track/feed_aggregator.cpp
+++ b/src/track/feed_aggregator.cpp
@@ -409,7 +409,7 @@ void Aggregator::HandleFeedDownloadOpen(FeedItem& feed_item,
         parameters = LR"(/directory "{}" "{}")"_format(download_path, file);
       // Deluge
       } else if (InStr(app_filename, L"deluge-console", 0, true) > -1) {
-        parameters = LR"(add -p \"{}\" \"{}\")"_format(download_path, file);
+        parameters = LR"(add -p \""{}\"" \""{}\"")"_format(download_path, file);
         show_command = SW_HIDE;
       // Transmission
       } else if (InStr(app_filename, L"transmission-remote", 0, true) > -1) {


### PR DESCRIPTION
Without double-quoting deluge-console fails to find torrent files whose names contain two consecutive spaces.