### PR TITLE
If using multiple instances show current service in titlebar and tray tip

### DIFF
--- a/src/ui/dlg/dlg_main.cpp
+++ b/src/ui/dlg/dlg_main.cpp
@@ -860,6 +860,9 @@ void MainDialog::UpdateTip() {
   if (taiga::app.options.debug_mode)
     tip += L" [debug]";
 
+  if (taiga::app.options.allow_multiple_instances)
+    tip += L" @ " + sync::GetCurrentServiceName();
+  
   if (const auto anime_item = anime::db.Find(CurrentEpisode.anime_id)) {
     tip += L"\nWatching: " + anime::GetPreferredTitle(*anime_item);
 
@@ -880,7 +883,7 @@ void MainDialog::UpdateTitle() {
   const auto display_name = taiga::GetCurrentUserDisplayName();
   if (!display_name.empty())
     title += L" \u2013 " + display_name;
-  if (taiga::app.options.debug_mode)
+  if (taiga::app.options.debug_mode || taiga::app.options.allow_multiple_instances)
     title += L" @ " + sync::GetCurrentServiceName();
 
   if (const auto anime_item = anime::db.Find(CurrentEpisode.anime_id)) {


### PR DESCRIPTION
When using the undocumented "-allowmultipleinstances" flag Taiga will show which anime tracking service that particular instance is using both in the tray tip and in the application title bar.  

Makes it a lot less confusing to determine which taiga is connected to which service when combining multiple instances with portable mode for a taiga running from its own folder for each service.  

Also helps to keep track of which one is which when cycling through them to make updates to the lists in the respective services.