### PR TITLE
Fix some minor build system annoyances

### DIFF
--- a/deps/build.bat
+++ b/deps/build.bat
@@ -35,6 +35,7 @@ if exist %vswhere% (
 
 :initialize_environment
 echo Initializing environment...
+setlocal
 call %vcvarsall% %machine% || (
   echo Please edit the build script according to your system configuration.
   exit /B 1
@@ -64,6 +65,8 @@ nmake /f Makefile.vc mode=static RTLIBCFG=static VC=%vc% MACHINE=%machine%
 xcopy /s ..\builds\libcurl-vc%vc%-%machine%-release-static-ipv6-sspi-schannel\lib ..\..\..\lib\%machine%\
 
 cd /D %currentdir%
+
+endlocal
 
 echo Done!
 pause

--- a/project/vs2019/Taiga.vcxproj
+++ b/project/vs2019/Taiga.vcxproj
@@ -153,6 +153,9 @@
     <Manifest>
       <AdditionalManifestFiles>..\..\res\Taiga.manifest</AdditionalManifestFiles>
     </Manifest>
+    <PostBuildEvent>
+      <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -177,6 +180,9 @@
     <Manifest>
       <AdditionalManifestFiles>..\..\res\Taiga.manifest</AdditionalManifestFiles>
     </Manifest>
+    <PostBuildEvent>
+      <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
@@ -231,6 +237,9 @@
     <Manifest>
       <AdditionalManifestFiles>..\..\res\Taiga.manifest</AdditionalManifestFiles>
     </Manifest>
+    <PostBuildEvent>
+      <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -261,6 +270,9 @@
     <Manifest>
       <AdditionalManifestFiles>..\..\res\Taiga.manifest</AdditionalManifestFiles>
     </Manifest>
+    <PostBuildEvent>
+      <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>

--- a/project/vs2019/Taiga.vcxproj
+++ b/project/vs2019/Taiga.vcxproj
@@ -156,6 +156,9 @@
     <PostBuildEvent>
       <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if not exist "..\..\deps\lib\$(LibrariesArchitecture)\libcurl_a.lib" ..\..\deps\build.bat --machine=$(LibrariesArchitecture)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -183,6 +186,9 @@
     <PostBuildEvent>
       <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if not exist "..\..\deps\lib\$(LibrariesArchitecture)\libcurl_a.lib" ..\..\deps\build.bat --machine=$(LibrariesArchitecture)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
@@ -240,6 +246,9 @@
     <PostBuildEvent>
       <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if not exist "..\..\deps\lib\$(LibrariesArchitecture)\libcurl_a.lib" ..\..\deps\build.bat --machine=$(LibrariesArchitecture)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -273,6 +282,9 @@
     <PostBuildEvent>
       <Command>xcopy ..\..\data $(OutputPath)\data /I /E /Y</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if not exist "..\..\deps\lib\$(LibrariesArchitecture)\libcurl_a.lib" ..\..\deps\build.bat --machine=$(LibrariesArchitecture)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>


### PR DESCRIPTION
I found it mildly annoying to have to run some steps manually before and after the main build, so this PR automates these steps for non-ARM builds (on ARM, MSBuild pre-/post-build steps don't seem to be supported).

It also fixes an issue in the dependency build script where the environment is modified for the whole session, which can cause it to fail due to `vcvarsall` trying to make (I assume) `PATH` too long when called multiple times.