### PR TITLE
Display selected list item count in status bar

### DIFF
--- a/src/ui/dlg/dlg_anime_list.cpp
+++ b/src/ui/dlg/dlg_anime_list.cpp
@@ -747,8 +747,14 @@ LRESULT AnimeListDialog::OnListNotify(LPARAM lParam) {
     case LVN_ITEMCHANGED: {
       auto lplv = reinterpret_cast<LPNMLISTVIEW>(lParam);
       auto anime_id = static_cast<int>(lplv->lParam);
+      auto selected_count = listview.GetSelectedCount();
       if (lplv->uNewState)
         listview.RefreshItem(lplv->iItem);
+      if (selected_count > 0) {
+        ui::ChangeStatusText(ToWstr(selected_count) + (selected_count == 1 ? L" item" : L" items") + L" selected");
+      } else {
+        ui::ClearStatusText();
+      }
       break;
     }
 
@@ -1424,6 +1430,9 @@ void AnimeListDialog::RefreshList(std::optional<anime::MyStatus> status) {
       current_position = listview.GetItemCount() - 1;
     listview.EnsureVisible(current_position);
   }
+
+  // Clear status bar text
+  ui::ClearStatusText();
 
   // Redraw
   listview.SetRedraw(TRUE);

--- a/src/ui/dlg/dlg_anime_list.cpp
+++ b/src/ui/dlg/dlg_anime_list.cpp
@@ -746,12 +746,12 @@ LRESULT AnimeListDialog::OnListNotify(LPARAM lParam) {
     // Item select
     case LVN_ITEMCHANGED: {
       auto lplv = reinterpret_cast<LPNMLISTVIEW>(lParam);
-      auto anime_id = static_cast<int>(lplv->lParam);
-      auto selected_count = listview.GetSelectedCount();
       if (lplv->uNewState)
         listview.RefreshItem(lplv->iItem);
+      const auto selected_count = listview.GetSelectedCount();
       if (selected_count > 0) {
-        ui::ChangeStatusText(ToWstr(selected_count) + (selected_count == 1 ? L" item" : L" items") + L" selected");
+        ui::ChangeStatusText(L"{} {} selected"_format(
+            selected_count, selected_count == 1 ? L"item" : L"items"));
       } else {
         ui::ClearStatusText();
       }
@@ -1431,7 +1431,7 @@ void AnimeListDialog::RefreshList(std::optional<anime::MyStatus> status) {
     listview.EnsureVisible(current_position);
   }
 
-  // Clear status bar text
+  // Clear status bar text, as it might be displaying selected item count
   ui::ClearStatusText();
 
   // Redraw


### PR DESCRIPTION
There are times when I wonder how many list items I have of a given category, date range, rating, etc. and the only way to get that number currently seems to be to copy the selected items, and paste the clipboard contents in a text editor that can count lines. This adds a "N item(s) selected" status bar message when selecting one or more list entries, which is cleared on refresh (on update, switching tabs, etc.). This doesn't seem to be problematic for other status messages, like network activity, that I've tested.