### PR TITLE
XML: Move version string into attribute

### DIFF
--- a/src/base/xml.cpp
+++ b/src/base/xml.cpp
@@ -114,17 +114,8 @@ bool XmlSaveDocumentToFile(const XmlDocument& document,
   return document.save_file(path.data(), indent.data(), flags, encoding);
 }
 
-std::wstring XmlReadMetaVersion(const XmlDocument& document) {
-  return XmlReadStr(document.child(L"meta"), L"version");
-}
-
 std::wstring XmlReadVersionAttr(const XmlNode& node) {
   return XmlReadAttr(node, L"version");
-}
-
-void XmlWriteMetaVersion(XmlDocument& document,
-                         const std::wstring_view version) {
-  XmlWriteStr(XmlChild(document, L"meta"), L"version", version);
 }
 
 void XmlWriteVersionAttr(XmlNode& node, const std::wstring_view version) {

--- a/src/base/xml.cpp
+++ b/src/base/xml.cpp
@@ -64,6 +64,10 @@ std::wstring XmlReadStr(const XmlNode& node, const std::wstring_view name) {
   return node.child_value(name.data());
 }
 
+std::wstring XmlReadAttr(const XmlNode& node, const std::wstring_view name) {
+  return node.attribute(name.data()).value();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void XmlWriteInt(XmlNode& node, const std::wstring_view name,
@@ -75,6 +79,11 @@ void XmlWriteStr(XmlNode& node, const std::wstring_view name,
                  const std::wstring_view value, pugi::xml_node_type node_type) {
   node.append_child(name.data())
       .append_child(node_type).set_value(value.data());
+}
+
+void XmlWriteAttr(XmlNode& node, const std::wstring_view name,
+                  const std::wstring_view value) {
+  XmlAttr(node, name).set_value(value.data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,7 +118,15 @@ std::wstring XmlReadMetaVersion(const XmlDocument& document) {
   return XmlReadStr(document.child(L"meta"), L"version");
 }
 
+std::wstring XmlReadVersionAttr(const XmlNode& node) {
+  return XmlReadAttr(node, L"version");
+}
+
 void XmlWriteMetaVersion(XmlDocument& document,
                          const std::wstring_view version) {
   XmlWriteStr(XmlChild(document, L"meta"), L"version", version);
+}
+
+void XmlWriteVersionAttr(XmlNode& node, const std::wstring_view version) {
+  XmlWriteAttr(node, L"version", version);
 }

--- a/src/base/xml.h
+++ b/src/base/xml.h
@@ -60,4 +60,6 @@ bool XmlSaveDocumentToFile(
     const pugi::xml_encoding encoding = pugi::xml_encoding::encoding_utf8);
 
 std::wstring XmlReadMetaVersion(const XmlDocument& document);
+std::wstring XmlReadVersionAttr(const XmlNode& node);
 void XmlWriteMetaVersion(XmlDocument& document, const std::wstring_view version);
+void XmlWriteVersionAttr(XmlNode& parent_node, const std::wstring_view version);

--- a/src/base/xml.h
+++ b/src/base/xml.h
@@ -59,7 +59,5 @@ bool XmlSaveDocumentToFile(
     const unsigned int flags = pugi::format_default,
     const pugi::xml_encoding encoding = pugi::xml_encoding::encoding_utf8);
 
-std::wstring XmlReadMetaVersion(const XmlDocument& document);
 std::wstring XmlReadVersionAttr(const XmlNode& node);
-void XmlWriteMetaVersion(XmlDocument& document, const std::wstring_view version);
 void XmlWriteVersionAttr(XmlNode& parent_node, const std::wstring_view version);

--- a/src/media/anime_db.cpp
+++ b/src/media/anime_db.cpp
@@ -45,12 +45,11 @@ bool Database::LoadDatabase() {
   if (!parse_result)
     return false;
 
-  const auto meta_version = XmlReadMetaVersion(document);
-
   auto database_node = document.child(L"database");
   ReadDatabaseNode(database_node);
 
-  HandleCompatibility(meta_version);
+  const auto xml_version = XmlReadVersionAttr(database_node);
+  HandleCompatibility(xml_version);
 
   return true;
 }
@@ -117,8 +116,9 @@ void Database::ReadDatabaseNode(XmlNode& database_node) {
 bool Database::SaveDatabase() const {
   XmlDocument document;
 
-  XmlWriteMetaVersion(document, StrToWstr(taiga::version().to_string()));
-  WriteDatabaseNode(XmlChild(document, L"database"));
+  auto database_node = XmlChild(document, L"database");
+  XmlWriteVersionAttr(database_node, StrToWstr(taiga::version().to_string()));
+  WriteDatabaseNode(database_node);
 
   const auto path = taiga::GetPath(taiga::Path::DatabaseAnime);
   return XmlSaveDocumentToFile(document, path);

--- a/src/media/library/history.cpp
+++ b/src/media/library/history.cpp
@@ -51,12 +51,14 @@ bool History::Load() {
   if (!parse_result)
     return false;
 
-  // Meta
-  const auto meta_version = XmlReadMetaVersion(document);
-  const semaver::Version version(WstrToStr(meta_version));
+  const auto history_node = document.child(L"history");
+
+  // Version handling
+  const auto xml_version = XmlReadVersionAttr(history_node);
+  const semaver::Version version(WstrToStr(xml_version));
 
   // Items
-  auto node_items = document.child(L"history").child(L"items");
+  auto node_items = history_node.child(L"items");
   for (auto item : node_items.children(L"item")) {
     HistoryItem history_item;
     history_item.anime_id = item.attribute(L"anime_id").as_int(anime::ID_NOTINLIST);
@@ -73,7 +75,7 @@ bool History::Load() {
   }
   // Queue events
   ReadQueue(document);
-  HandleCompatibility(meta_version);
+  HandleCompatibility(xml_version);
 
   return true;
 }
@@ -123,11 +125,10 @@ void History::ReadQueue(const XmlDocument& document) {
 
 bool History::Save() {
   XmlDocument document;
-
-  // Write meta
-  XmlWriteMetaVersion(document, StrToWstr(taiga::version().to_string()));
-
   auto node_history = document.append_child(L"history");
+
+  // Write version attribute
+  XmlWriteVersionAttr(node_history, StrToWstr(taiga::version().to_string()));
 
   // Write items
   auto node_items = node_history.append_child(L"items");

--- a/src/media/library/list.cpp
+++ b/src/media/library/list.cpp
@@ -48,8 +48,6 @@ bool Database::LoadList() {
     return false;
   }
 
-  const auto meta_version = XmlReadMetaVersion(document);
-
   auto node_database = document.child(L"database");
   ReadDatabaseNode(node_database);
 
@@ -74,7 +72,8 @@ bool Database::LoadList() {
     anime_item.SetMyLastUpdated(XmlReadStr(node, L"last_updated"));
   }
 
-  HandleListCompatibility(meta_version);
+  const auto xml_version = XmlReadVersionAttr(node_library);
+  HandleListCompatibility(xml_version);
 
   return true;
 }
@@ -85,13 +84,13 @@ bool Database::SaveList(bool include_database) const {
 
   XmlDocument document;
 
-  XmlWriteMetaVersion(document, StrToWstr(taiga::version().to_string()));
-
   if (include_database) {
     WriteDatabaseNode(XmlChild(document, L"database"));
   }
 
   auto node_library = document.append_child(L"library");
+
+  XmlWriteVersionAttr(node_library, StrToWstr(taiga::version().to_string()));
 
   for (const auto& [id, item] : items) {
     if (item.IsInList()) {


### PR DESCRIPTION
Closes #842.

This PR changes the read and write functions for `data/db/anime.xml`, `data/user/<user@service>/anime.xml` and `data/user/<user@service>/history.xml`.

It does not change `/data/feed/history.xml` (does not contain a version string) or `/data/settings.xml` (see #842, there is a meta element, but it is inside another element so the XML is already valid)

Related to XmlReadAttr: Calling `.value()` on an attribute that might not exist is allowed as per [documentation](https://pugixml.org/docs/manual.html#access.attrdata):
> In case the attribute handle is null, both functions return empty strings - they never return null pointers.

