### PR TITLE
chore: remove Hibari from default external links

### DIFF
--- a/src/taiga/settings_keys.cpp
+++ b/src/taiga/settings_keys.cpp
@@ -47,7 +47,6 @@
 namespace taiga {
 
 constexpr auto kDefaultExternalLinks =
-    L"Hibari|https://hb.wopian.me\r\n"
     L"MALgraph|http://graph.anime.plus\r\n"
     L"-\r\n"
     L"AniChart|http://anichart.net/airing\r\n"


### PR DESCRIPTION
I never had the time to finish developing this project and will likely not be renewing the hibari.moe domain in 2023.

The redirect from hb.wopian.me to hibari.moe has already been removed (in 2021 or 2022) so this link already points to nothing.