### PR TITLE
Update Jellyfin Integration

### DIFF
--- a/src/track/media_stream.cpp
+++ b/src/track/media_stream.cpp
@@ -77,8 +77,9 @@ static const std::vector<StreamData> stream_data{
     L"Jellyfin Web App",
     L"https://jellyfin.org",
     std::regex(
-      "^localhost:[0-9]+/web/index.html#!/video|"
-      "^.+/jellyfin/web/index.html#!/video"
+      "^localhost:\\d+/web/index\\.html#/video|"
+      "^.+/jellyfin/web/index\\.html#/video|"
+      "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+/web/index\\.html#/video"
     ),
     std::regex("Jellyfin|(.+)"),
   },

--- a/src/track/media_stream.cpp
+++ b/src/track/media_stream.cpp
@@ -77,9 +77,7 @@ static const std::vector<StreamData> stream_data{
     L"Jellyfin Web App",
     L"https://jellyfin.org",
     std::regex(
-      "^localhost:\\d+/web/index\\.html#/video|"
-      "^.+/jellyfin/web/index\\.html#/video|"
-      "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+/web/index\\.html#/video"
+      "^.+/web/(?:index\\.html)?#!/video"
     ),
     std::regex("Jellyfin|(.+)"),
   },

--- a/src/track/media_stream.cpp
+++ b/src/track/media_stream.cpp
@@ -76,9 +76,7 @@ static const std::vector<StreamData> stream_data{
     Stream::Jellyfin,
     L"Jellyfin Web App",
     L"https://jellyfin.org",
-    std::regex(
-      "^.+/web/(?:index\\.html)?#!/video"
-    ),
+    std::regex("^.+/web/(?:index\\.html)?#!/video"),
     std::regex("Jellyfin|(.+)"),
   },
   // Plex Web App


### PR DESCRIPTION
The current Version of the Jellyfin integration had an erroneous ! in the Regex, which has been removed in this PR. Also allow finding it, in the same way as Plex is detected, via IP.