### PR TITLE
MAL: add new types

### DIFF
--- a/src/sync/myanimelist_util.cpp
+++ b/src/sync/myanimelist_util.cpp
@@ -119,6 +119,9 @@ anime::SeriesType TranslateSeriesTypeFrom(const std::wstring& value) {
     {L"ova", anime::SeriesType::Ova},
     {L"movie", anime::SeriesType::Movie},
     {L"special", anime::SeriesType::Special},
+    {L"tv_special", anime::SeriesType::Special},
+    {L"cm", anime::SeriesType::Special},
+    {L"pv", anime::SeriesType::Special},
     {L"ona", anime::SeriesType::Ona},
     {L"music", anime::SeriesType::Music},
   };

--- a/src/sync/myanimelist_util.cpp
+++ b/src/sync/myanimelist_util.cpp
@@ -119,11 +119,11 @@ anime::SeriesType TranslateSeriesTypeFrom(const std::wstring& value) {
     {L"ova", anime::SeriesType::Ova},
     {L"movie", anime::SeriesType::Movie},
     {L"special", anime::SeriesType::Special},
-    {L"tv_special", anime::SeriesType::Special},
-    {L"cm", anime::SeriesType::Special},
-    {L"pv", anime::SeriesType::Special},
     {L"ona", anime::SeriesType::Ona},
     {L"music", anime::SeriesType::Music},
+    {L"cm", anime::SeriesType::Special},
+    {L"pv", anime::SeriesType::Special},
+    {L"tv_special", anime::SeriesType::Special},
   };
 
   const auto it = table.find(ToLower_Copy(value));


### PR DESCRIPTION
Added 3 missing types:
- Commercial (cm)
- Promotional video (pv) 
- TV special. 

Currently all just mapped to special. but if needed I can do a proper support for each type. I didnt have the time to check if any other service had any missing ones, this was just from my own usage.