### PR TITLE
[Suggestion] [Library] Set watched episodes to 0 when moving out of completed

### DIFF
--- a/src/ui/command.cpp
+++ b/src/ui/command.cpp
@@ -575,6 +575,10 @@ void ExecuteCommand(const std::wstring& str, WPARAM wParam, LPARAM lParam) {
       auto anime_item = anime::db.Find(anime_id);
       if (!anime_item)
         continue;
+      auto prev_status = anime_item->GetMyStatus();   
+      if (prev_status == anime::MyStatus::Completed) {
+        queue_item.episode = 0;
+      }
       switch (*queue_item.status) {
         case anime::MyStatus::Completed:
           queue_item.episode = anime_item->GetEpisodeCount();

--- a/src/ui/command.cpp
+++ b/src/ui/command.cpp
@@ -575,8 +575,10 @@ void ExecuteCommand(const std::wstring& str, WPARAM wParam, LPARAM lParam) {
       auto anime_item = anime::db.Find(anime_id);
       if (!anime_item)
         continue;
-      auto prev_status = anime_item->GetMyStatus();   
-      if (prev_status == anime::MyStatus::Completed) {
+      auto prev_status = anime_item->GetMyStatus();
+      auto prev_full_watched_ep = anime_item->GetMyLastWatchedEpisode();
+      auto prev_full_ep = anime_item->GetEpisodeCount();
+      if (prev_status == anime::MyStatus::Completed && prev_full_watched_ep == prev_full_ep) {
         queue_item.episode = 0;
       }
       switch (*queue_item.status) {


### PR DESCRIPTION
When an anime is moved from "Completed", it's typically because it's being rewatched (or will be rewatched in the future). In most cases, I don't see the need to retain the count of previously watched episodes. This code is more of a demonstration rather than a comprehensive implementation (for obvious reasons) but it works completely. 