### PR TITLE
Refactor presets and add windows-clang preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.29)
 
 project(Taiga
 	VERSION 2.0.0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,39 +2,72 @@
   "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 29,
     "patch": 0
   },
+  "include": [
+    "cmake/presets/ninja.json",
+    "cmake/presets/windows.json"
+  ],
   "configurePresets": [
     {
-      "name": "ninja-multi",
-      "displayName": "Ninja Multi-Config",
-      "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
-      "toolset": {
-        "value": "host=x64",
-        "strategy": "external"
-      },
+      "name": "windows-msvc",
+      "inherits": [
+        "ninja",
+        "windows"
+      ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl.exe"
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl"
+      }
+    },
+    {
+      "name": "windows-clang",
+      "inherits": [
+        "ninja",
+        "windows"
+      ],
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang++.exe",
+        "CMAKE_CXX_COMPILER": "clang++.exe"
       }
     }
   ],
   "buildPresets": [
     {
-      "name": "ninja-debug",
-      "configurePreset": "ninja-multi",
-      "displayName": "Debug",
+      "name": "windows-msvc",
+      "inherits": [
+        "ninja",
+        "windows"
+      ],
+      "configurePreset": "windows-msvc",
       "configuration": "Debug"
     },
     {
-      "name": "ninja-release",
-      "configurePreset": "ninja-multi",
-      "displayName": "Release",
+      "name": "windows-msvc-release",
+      "inherits": [
+        "ninja",
+        "windows"
+      ],
+      "configurePreset": "windows-msvc",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "windows-clang",
+      "inherits": [
+        "ninja",
+        "windows"
+      ],
+      "configurePreset": "windows-clang",
+      "configuration": "Debug"
+    },
+    {
+      "name": "windows-clang-release",
+      "inherits": [
+        "ninja",
+        "windows"
+      ],
+      "configurePreset": "windows-clang",
       "configuration": "RelWithDebInfo"
     }
   ]

--- a/cmake/presets/ninja.json
+++ b/cmake/presets/ninja.json
@@ -1,0 +1,27 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "ninja",
+            "hidden": true,
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/build/${presetName}"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "ninja",
+            "hidden": true,
+            "configurePreset": "ninja",
+            "configuration": "Debug"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "ninja",
+            "hidden": true,
+            "configurePreset": "ninja",
+            "configuration": "Debug"
+        }
+    ]
+}

--- a/cmake/presets/windows.json
+++ b/cmake/presets/windows.json
@@ -1,0 +1,36 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "windows",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            },
+            "toolset": {
+                "value": "host=x64",
+                "strategy": "external"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "windows",
+            "hidden": true,
+            "configurePreset": "windows"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "windows",
+            "hidden": true,
+            "configurePreset": "windows"
+        }
+    ]
+}


### PR DESCRIPTION
Put presets that should not be used directly into the subfolder cmake, so they are out of the way.

Create re-usable presets in ninja and windows that can be re-used by other presets.

Re-name the base ninja-multi preset into windows-msvc preset in order to distinguish it from the new windows-clang preset.

Added build presets for debug and release modes.

```
PS C:\Users\nunor\Documents\GitHub\taiga> cmake --list-presets
Available configure presets:

  "windows-msvc"
  "windows-clang"
PS C:\Users\nunor\Documents\GitHub\taiga> cmake --build --list-presets
Available build presets:

  "windows-msvc"
  "windows-msvc-release"
  "windows-clang"
  "windows-clang-release"
PS C:\Users\nunor\Documents\GitHub\taiga>
```