### PR TITLE
Display current anime in Discord status instead of "Playing Taiga"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 
 [submodule "discord-rpc"]
 	path = deps/src/discord-rpc
-	url = https://github.com/erengy/discord-rpc.git
+	url = https://github.com/ungive/discord-rpc.git
 
 [submodule "fmt"]
 	path = deps/src/fmt

--- a/src/link/discord.cpp
+++ b/src/link/discord.cpp
@@ -87,6 +87,10 @@ void UpdatePresence(const std::string& details, const std::string& state,
           : WstrToStr(sync::GetCurrentServiceName());
 
   DiscordRichPresence presence = {0};
+  if (taiga::settings.GetShareDiscordWatchingEnabled()) {
+    presence.type = DiscordActivityType_Watching;
+    presence.status_display_type = DiscordStatusDisplayType_Details;
+  }
   presence.state = state.c_str();
   presence.details = details.c_str();
   if (taiga::settings.GetShareDiscordTimeEnabled()) {

--- a/src/taiga/resource.h
+++ b/src/taiga/resource.h
@@ -215,3 +215,4 @@
 #define IDC_CHECK_DISCORD_TIME                  1178
 #define IDC_EDIT_ANIME_REWATCHES                1179
 #define IDC_SPIN_ANIME_REWATCHES                1180
+#define IDC_CHECK_DISCORD_WATCHING              1181

--- a/src/taiga/resource.rc
+++ b/src/taiga/resource.rc
@@ -538,11 +538,12 @@ EXSTYLE WS_EX_CONTROLPARENT
 FONT 9, "Segoe UI", 400, 0, 0
 {
     AUTOCHECKBOX    "Update rich presence", IDC_CHECK_DISCORD, 7, 7, 100, 8, 0, WS_EX_LEFT
-    GROUPBOX        "Options", IDC_STATIC, 7, 22, 301, 48, 0, WS_EX_LEFT
+    GROUPBOX        "Options", IDC_STATIC, 7, 22, 301, 60, 0, WS_EX_LEFT
     AUTOCHECKBOX    "Display username in tooltip", IDC_CHECK_DISCORD_USERNAME, 13, 33, 135, 8, 0, WS_EX_LEFT
     AUTOCHECKBOX    "Display episode release group", IDC_CHECK_DISCORD_GROUP, 13, 44, 135, 8, 0, WS_EX_LEFT
     AUTOCHECKBOX    "Display elapsed time", IDC_CHECK_DISCORD_TIME, 13, 55, 135, 8, 0, WS_EX_LEFT
-    LTEXT           "Note: Requires using the Discord desktop client. ""Display current activity as a status message"" option must be enabled, but do not add Taiga as a game. Updates may be delayed for 15 seconds, in addition to the delay time setting at Recognition page.", IDC_STATIC, 7, 77, 301, 26, SS_LEFT, WS_EX_TRANSPARENT
+    AUTOCHECKBOX    "Display current anime in status instead of ""Playing Taiga""", IDC_CHECK_DISCORD_WATCHING, 13, 66, 200, 8, 0, WS_EX_LEFT
+    LTEXT           "Note: Requires using the Discord desktop client. ""Display current activity as a status message"" option must be enabled, but do not add Taiga as a game. Updates may be delayed for 15 seconds, in addition to the delay time setting at Recognition page.", IDC_STATIC, 7, 88, 301, 26, SS_LEFT, WS_EX_TRANSPARENT
 }
 
 

--- a/src/taiga/settings.h
+++ b/src/taiga/settings.h
@@ -248,6 +248,8 @@ public:
   void SetShareDiscordTimeEnabled(const bool enabled);
   bool GetShareDiscordUsernameEnabled() const;
   void SetShareDiscordUsernameEnabled(const bool enabled);
+  bool GetShareDiscordWatchingEnabled() const;
+  void SetShareDiscordWatchingEnabled(const bool enabled);
   bool GetShareHttpEnabled() const;
   void SetShareHttpEnabled(const bool enabled);
   std::wstring GetShareHttpFormat() const;

--- a/src/taiga/settings_keys.cpp
+++ b/src/taiga/settings_keys.cpp
@@ -185,6 +185,7 @@ void Settings::InitKeyMap() const {
       {AppSettingKey::ShareDiscordGroupEnabled, {"announce/discord/groupenabled", true}},
       {AppSettingKey::ShareDiscordTimeEnabled, {"announce/discord/timeenabled", true}},
       {AppSettingKey::ShareDiscordUsernameEnabled, {"announce/discord/usernameenabled", true}},
+      {AppSettingKey::ShareDiscordWatchingEnabled, {"announce/discord/watchingenabled", true}},
       {AppSettingKey::ShareHttpEnabled, {"announce/http/enabled", false}},
       {AppSettingKey::ShareHttpFormat, {"announce/http/format", std::wstring{kDefaultFormatHttp}}},
       {AppSettingKey::ShareHttpUrl, {"announce/http/url", std::wstring{}}},
@@ -1028,6 +1029,14 @@ bool Settings::GetShareDiscordUsernameEnabled() const {
 
 void Settings::SetShareDiscordUsernameEnabled(const bool enabled) {
   set_value(AppSettingKey::ShareDiscordUsernameEnabled, enabled);
+}
+
+bool Settings::GetShareDiscordWatchingEnabled() const {
+  return value<bool>(AppSettingKey::ShareDiscordWatchingEnabled);
+}
+
+void Settings::SetShareDiscordWatchingEnabled(const bool enabled) {
+  set_value(AppSettingKey::ShareDiscordWatchingEnabled, enabled);
 }
 
 bool Settings::GetShareHttpEnabled() const {

--- a/src/taiga/settings_keys.h
+++ b/src/taiga/settings_keys.h
@@ -114,6 +114,7 @@ enum class AppSettingKey {
   ShareDiscordGroupEnabled,
   ShareDiscordTimeEnabled,
   ShareDiscordUsernameEnabled,
+  ShareDiscordWatchingEnabled,
   ShareHttpEnabled,
   ShareHttpFormat,
   ShareHttpUrl,

--- a/src/ui/dlg/dlg_settings.cpp
+++ b/src/ui/dlg/dlg_settings.cpp
@@ -283,6 +283,7 @@ void SettingsDialog::OnOK() {
     taiga::settings.SetShareDiscordUsernameEnabled(page->IsDlgButtonChecked(IDC_CHECK_DISCORD_USERNAME));
     taiga::settings.SetShareDiscordGroupEnabled(page->IsDlgButtonChecked(IDC_CHECK_DISCORD_GROUP));
     taiga::settings.SetShareDiscordTimeEnabled(page->IsDlgButtonChecked(IDC_CHECK_DISCORD_TIME));
+    taiga::settings.SetShareDiscordWatchingEnabled(page->IsDlgButtonChecked(IDC_CHECK_DISCORD_WATCHING));
   }
   // Sharing > HTTP
   page = &pages[kSettingsPageSharingHttp];

--- a/src/ui/dlg/dlg_settings_page.cpp
+++ b/src/ui/dlg/dlg_settings_page.cpp
@@ -297,6 +297,7 @@ BOOL SettingsPage::OnInitDialog() {
       CheckDlgButton(IDC_CHECK_DISCORD_USERNAME, taiga::settings.GetShareDiscordUsernameEnabled());
       CheckDlgButton(IDC_CHECK_DISCORD_GROUP, taiga::settings.GetShareDiscordGroupEnabled());
       CheckDlgButton(IDC_CHECK_DISCORD_TIME, taiga::settings.GetShareDiscordTimeEnabled());
+      CheckDlgButton(IDC_CHECK_DISCORD_WATCHING, taiga::settings.GetShareDiscordWatchingEnabled());
       break;
     }
     // Sharing > HTTP


### PR DESCRIPTION
Here's what it looks like:
<img width="237" height="49" alt="image" src="https://github.com/user-attachments/assets/a9e5b01d-73e0-48c2-b0f2-42005ca2758c" />
<img width="276" height="47" alt="image" src="https://github.com/user-attachments/assets/3c14e293-e19b-4aee-9e05-81298f94a87d" />

Corresponding option and when it's disabled:
<img width="568" height="264" alt="image" src="https://github.com/user-attachments/assets/7fffb311-ad42-446d-a078-8540f71f28ca" />

<img width="197" height="41" alt="image" src="https://github.com/user-attachments/assets/978bb525-2f69-43e0-82db-a17ec3c2945d" />